### PR TITLE
feat: Revcord can now be used with self-hosted instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ REVOLT_TOKEN = ...
 ```
 Of course, replace ... with tokens.
 
+If you are running a self-hosted instance of revolt, additionally set the `API_URL` variable:
+```
+REVOLT_TOKEN = https://api.revolt.chat
+```
+
 4. **Important!** Make sure to select the following permissions in URL Generator when making an invite for your bot (Your bot in Discord Developers -> `OAuth2` -> `URL Generator`) (or if you're lazy, just select `Administrator`) Note **applications.commands**!
    
 ![permissions](docs/permissions.png)

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ REVOLT_TOKEN = ...
 ```
 Of course, replace ... with tokens.
 
-If you are running a self-hosted instance of revolt, additionally set the `API_URL` variable:
+If you are running a self-hosted instance of Revolt, additionally set the `API_URL` variable:
 ```
-REVOLT_TOKEN = https://api.revolt.chat
+API_URL = https://api.revolt.chat
 ```
 
 4. **Important!** Make sure to select the following permissions in URL Generator when making an invite for your bot (Your bot in Discord Developers -> `OAuth2` -> `URL Generator`) (or if you're lazy, just select `Administrator`) Note **applications.commands**!

--- a/app/Bot.ts
+++ b/app/Bot.ts
@@ -142,7 +142,7 @@ export class Bot {
   }
 
   setupRevoltBot() {
-    this.revolt = new RevoltClient();
+    this.revolt = new RevoltClient({apiURL: process.env.API_URL});
 
     this.revolt.once("ready", () => {
       npmlog.info("Revolt", `Logged in as ${this.revolt.user.username}`);


### PR DESCRIPTION
Revcord can now be used with self-hosted instances by setting the API_URL environment variable.

If the `API_URL` environment variable is undefined, the default ([https://api.revolt.chat](https://api.revolt.chat)) will be used.