### PR TITLE
fix: improve revolt message updating

### DIFF
--- a/app/Bot.ts
+++ b/app/Bot.ts
@@ -114,7 +114,7 @@ export class Bot {
     });
 
     this.discord.on("messageCreate", (message) =>
-      handleDiscordMessage(this.revolt, this.discord, message)
+      handleDiscordMessage(this.revolt, this.discord, message, this.executor)
     );
 
     this.discord.on("messageUpdate", (oldMessage, newMessage) => {
@@ -125,6 +125,7 @@ export class Bot {
         attachments: oldMessage.attachments,
         channelId: oldMessage.channelId,
         content: newMessage.content,
+        embeds: newMessage.embeds,
         id: newMessage.id,
         mentions: newMessage.mentions,
       };

--- a/app/interfaces.ts
+++ b/app/interfaces.ts
@@ -3,6 +3,7 @@ import {
   Collection,
   CommandInteraction,
   MessageAttachment,
+  MessageEmbed,
   MessageMentions,
   User,
 } from "discord.js";
@@ -57,6 +58,7 @@ export interface PartialDiscordMessage {
   attachments: Collection<string, MessageAttachment>;
   channelId: string;
   content: string;
+  embeds: MessageEmbed[];
   id: string;
   mentions: MessageMentions;
 }


### PR DESCRIPTION
Two changes here pretty much:
- Update embeds if they've changed
- Revolt throws a FailedValidation error if content is empty when updating so check for that