### PR TITLE
Implemented Revolt => Discord emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - [x] Bridge emoji[^1]
 - [x] Seamlessly display user information
 
-[^1]: Revolt to Discord works, but limited to 3 emojis displayed to stop bombing with links
+[^1]: Revolt to Discord works, but limited to 3 emojis displayed to stop bombing with links. Animated emojis from Revolt will convert to static due to limits on Revolt's image backend
 
 ![Screenshot - Revolt](docs/discord.png) ![Screenshot - Discord](docs/revolt.png)
 
@@ -56,10 +56,11 @@ REVOLT_TOKEN = ...
 
 Of course, replace ... with tokens.
 
-If you are running a self-hosted instance of Revolt, additionally set the `API_URL` variable:
+If you are running a self-hosted instance of Revolt, additionally set the `API_URL` and `REVOLT_ATTACHMENT_URL` variable:
 
 ```
 API_URL = https://api.revolt.chat
+REVOLT_ATTACHMENT_URL = https://autumn.revolt.chat
 ```
 
 4. **Important!** Make sure to select the following permissions in URL Generator when making an invite for your bot (Your bot in Discord Developers -> `OAuth2` -> `URL Generator`) (or if you're lazy, just select `Administrator`) Note **applications.commands**!

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - [x] Bridge emoji[^1]
 - [x] Seamlessly display user information
 
-[^1]: Discord to Revolt only
+[^1]: Revolt to Discord works, but limited to 3 emojis displayed to stop bombing with links
 
 ![Screenshot - Revolt](docs/discord.png) ![Screenshot - Discord](docs/revolt.png)
 

--- a/app/revolt.ts
+++ b/app/revolt.ts
@@ -79,7 +79,8 @@ async function formatMessage(revolt: RevoltClient, message: Message) {
 
           // Limited to 3 to stop bombing with links
           if (i < 3) {
-            emojiUrl = `https://autumn.revolt.chat/emojis/${encodeURIComponent(emojiId)}/?width=32&quality=lossless`
+            const REVOLT_ATTACHMENT_URL = process.env.REVOLT_ATTACHMENT_URL || "https://autumn.revolt.chat"
+            emojiUrl = `${REVOLT_ATTACHMENT_URL}/emojis/${encodeURIComponent(emojiId)}/?width=32&quality=lossless`
             content = content.replace(emoji, emojiUrl)
           }
         }

--- a/app/revolt.ts
+++ b/app/revolt.ts
@@ -4,7 +4,7 @@ import { Client as RevoltClient } from "revolt.js";
 import { Message } from "revolt.js/dist/maps/Messages";
 import { AttachmentType, ReplyObject, RevoltSourceParams } from "./interfaces";
 import { Main } from "./Main";
-import { RevoltChannelPattern, RevoltPingPattern } from "./util/regex";
+import { RevoltChannelPattern, RevoltEmojiPattern, RevoltPingPattern } from "./util/regex";
 
 /**
  * This file contains code taking care of things from Revolt to Discord
@@ -61,6 +61,30 @@ async function formatMessage(revolt: RevoltClient, message: Message) {
         }
       }
     }
+  }
+
+  // Handle emojis 
+  const emojis = content.match(RevoltEmojiPattern);
+  if (emojis) {
+    emojis.forEach((emoji, i) => {
+      const dissected = RevoltEmojiPattern.exec(emoji);
+
+      RevoltEmojiPattern.lastIndex = 0;
+
+      if (dissected != null) {
+        const emojiId = dissected.groups["id"];
+
+        if (emojiId) {
+          let emojiUrl: string;
+
+          // Limited to 3 to stop bombing with links
+          if (i < 3) {
+            emojiUrl = `https://autumn.revolt.chat/emojis/${encodeURIComponent(emojiId)}/?width=32&quality=lossless`
+            content = content.replace(emoji, emojiUrl)
+          }
+        }
+      }
+    })
   }
 
   messageString += content + "\n";

--- a/app/util/regex.ts
+++ b/app/util/regex.ts
@@ -2,5 +2,6 @@ export const DiscordEmojiPattern = /<(:|a:)(?<name>.+?):(?<id>[0-9]{1,22})>/g;
 export const DiscordPingPattern = /<(@|@!)(?<id>[0-9]{1,22})>/g;
 export const DiscordChannelPattern = /<#(?<id>[0-9]{1,22})>/g;
 
+export const RevoltEmojiPattern = /:(?<id>[0-Z]{1,26}):/g
 export const RevoltPingPattern = /<@(?<id>[0-Z]{1,26})>/g;
 export const RevoltChannelPattern = /<#(?<id>[0-Z]{1,26})>/g;


### PR DESCRIPTION
Since Revolt emojis are just attachments, I implemented it exactly the same way as Discord => Revolt emoji. Here's only two limits:
- Limited to 3 to stop bombing with links
- Animated from Revolt will automatically convert to static since Revolt's autumn does not scale animated (might related to https://github.com/revoltchat/autumn/issues/13)