### PR TITLE
Removed trailing newlines in bridged messages

### DIFF
--- a/app/discord.ts
+++ b/app/discord.ts
@@ -15,6 +15,7 @@ import {
   DiscordChannelPattern,
   DiscordEmojiPattern,
   DiscordPingPattern,
+  TrailingNewlines,
 } from "./util/regex";
 import { RevcordEmbed } from "./util/embeds";
 import { checkWebhookPermissions } from "./util/permissions";
@@ -118,6 +119,8 @@ function formatMessage(
   });
 
   if (stickerUrl) messageString += stickerUrl + "\n";
+
+  messageString = messageString.replace(TrailingNewlines, '');
 
   return messageString;
 }
@@ -267,11 +270,11 @@ export async function handleDiscordMessage(
       if (message.embeds.length && message.author.bot) {
         // Add an empty array
         if (typeof messageObject.embeds === "undefined") messageObject.embeds = [];
-
+        
         // Translate embed
         try {
           const embed = new RevcordEmbed().fromDiscord(message.embeds[0]).toRevolt();
-
+          
           messageObject.embeds.push(embed);
         } catch (e) {
           npmlog.warn("Discord", "Failed to translate embed.");

--- a/app/util/regex.ts
+++ b/app/util/regex.ts
@@ -5,3 +5,5 @@ export const DiscordChannelPattern = /<#(?<id>[0-9]{1,22})>/g;
 export const RevoltEmojiPattern = /:(?<id>[0-Z]{1,26}):/g;
 export const RevoltPingPattern = /<@(?<id>[0-Z]{1,26})>/g;
 export const RevoltChannelPattern = /<#(?<id>[0-Z]{1,26})>/g;
+
+export const TrailingNewlines = /[\s\r\n]+$/;


### PR DESCRIPTION
Essentially there is a trailing newline at the end of bridged messages from discord to revolt, which is not present on the original message. 
Since it only happens with messages send from discord and viewed in revolt I've only added the fix in discord.ts formatMessage as everything else seems to be working fine and I did not want to break something else.

Discord on left, Revolt on right

Before
![before pic](https://i.imgur.com/eHiWFAZ.png)

After
![after pic](https://i.imgur.com/x7LjN08.png)

Bonus, pic showing the issue does not happen when sending messages from revolt to discord.
![bonus pic](https://i.imgur.com/jLtmq7f.png)

I've ran the setup process on two different server pairs with two different bots just to make sure this wasn't a setup or server issue.

Not entirely sure if I'm the only one bothered by this, if nobody faced this issue so far or if I'm just the first one to make a PR for it...